### PR TITLE
feat: 날짜/작성자/제목만 필터 UI/UX 고도화 및 실제 문서 목록 필터링 구현 (#4)

### DIFF
--- a/.cursor/rules/memory-bank/progress.md
+++ b/.cursor/rules/memory-bank/progress.md
@@ -20,3 +20,6 @@
 - TrashModal 위치 계산 useLayoutEffect에 anchorRef, dialogRef, getBoundingClientRect 예외 및 경고 추가 (2024-06-12)
 - TrashModal 위치 계산에서 dialogRef.current가 null일 때 setTimeout으로 1프레임 뒤에 위치 계산을 재시도하도록 개선 (2024-06-12)
 - TrashModal 위치 계산 로직을 calculateDialogPosition 함수로 분리하고, useLayoutEffect 내 중복 코드를 제거해 리팩토링 (2024-06-12)
+- 작성자 필터 모달이 드롭다운처럼 버튼(anchorRef) 아래에 자연스럽게 위치하도록 수정. SearchFilters의 작성자 버튼에 ref를 부여해 AuthorFilterModal에 anchorRef로 전달, absolute 위치 계산 및 오버레이 제거까지 완료.
+- 날짜 필터(DateFilterModal) 드롭다운 모달 컴포넌트 생성 및 SearchFilters, SearchModal과 연동. 날짜 버튼 클릭 시 모달 오픈, 오늘/이번 주/이번 달/직접 선택 등 프리셋 선택 가능. 선택 시 버튼에 라벨 표시. (직접 선택은 미구현)
+- DateFilterModal에서 '직접 선택' 버튼 제거 및 showCalendar를 항상 true로 고정하여, 모달이 열리면 바로 캘린더가 보이도록 개선 (2024-06-09)

--- a/frontend/src/components/layout/AuthorFilterModal.jsx
+++ b/frontend/src/components/layout/AuthorFilterModal.jsx
@@ -1,0 +1,95 @@
+import React, { useState, useMemo, useEffect, useRef, useLayoutEffect } from 'react';
+
+export default function AuthorFilterModal({ open, onClose, authors = [], onSelectAuthor, selectedAuthor, anchorRef }) {
+  const [search, setSearch] = useState('');
+  const [position, setPosition] = useState({ top: 0, left: 0, minWidth: 180 });
+  const modalRef = useRef(null);
+  const inputRef = useRef(null);
+
+  // 위치 계산
+  useLayoutEffect(() => {
+    if (!open || !anchorRef?.current || !modalRef.current) return;
+    const rect = anchorRef.current.getBoundingClientRect();
+    setPosition({
+      top: rect.bottom + window.scrollY + 4,
+      left: rect.left + window.scrollX,
+      minWidth: rect.width || 180,
+    });
+  }, [open, anchorRef]);
+
+  // 외부 클릭 시 닫기
+  useEffect(() => {
+    if (!open) return;
+    function handleClick(e) {
+      if (
+        modalRef.current && !modalRef.current.contains(e.target) &&
+        anchorRef?.current && !anchorRef.current.contains(e.target)
+      ) {
+        onClose();
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open, onClose, anchorRef]);
+
+  // 자동 포커스
+  useEffect(() => {
+    if (open && inputRef.current) inputRef.current.focus();
+    if (!open) setSearch('');
+  }, [open]);
+
+  // 검색어로 필터링
+  const filteredAuthors = useMemo(() => {
+    if (!search.trim()) return authors;
+    const lower = search.toLowerCase();
+    return authors.filter(a => a.name.toLowerCase().includes(lower));
+  }, [search, authors]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={modalRef}
+      style={{
+        position: 'absolute',
+        top: position.top,
+        left: position.left,
+        minWidth: position.minWidth,
+        zIndex: 1000,
+        boxShadow: '0 4px 24px rgba(0,0,0,0.08)',
+      }}
+      className="p-4 bg-white border border-gray-200 rounded-lg"
+    >
+      <div className="mb-2">
+        <input
+          ref={inputRef}
+          type="text"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          placeholder="작성자 이름 검색"
+          className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none"
+        />
+      </div>
+      <ul className="overflow-y-auto divide-y divide-gray-100 max-h-60">
+        <li
+          className={`py-2 px-2 cursor-pointer rounded ${!selectedAuthor ? 'bg-gray-100' : 'hover:bg-gray-200'}`}
+          onClick={() => { onSelectAuthor(''); onClose(); }}
+        >
+          전체
+        </li>
+        {filteredAuthors.map(author => (
+          <li
+            key={author.userId}
+            className={`py-2 px-2 cursor-pointer rounded flex items-center gap-2 ${selectedAuthor === author.userId ? 'bg-gray-100' : 'hover:bg-gray-200'}`}
+            onClick={() => { onSelectAuthor(author.userId); onClose(); }}
+          >
+            <div className="flex items-center justify-center w-8 h-8 text-base font-bold text-gray-700 bg-gray-200 rounded-full select-none">
+              {author.name ? author.name.charAt(0).toUpperCase() : '?'}
+            </div>
+            <span>{author.name}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+} 

--- a/frontend/src/components/layout/DateFilterModal.jsx
+++ b/frontend/src/components/layout/DateFilterModal.jsx
@@ -1,0 +1,249 @@
+import React, { useRef, useLayoutEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+const PRESETS = [
+  { label: '오늘', value: 'today' },
+  { label: '이번 주', value: 'week' },
+  { label: '이번 달', value: 'month' },
+];
+
+function getDaysInMonth(year, month) {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+function isSameDay(a, b) {
+  return a && b && a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+}
+
+function isInRange(day, start, end) {
+  if (!start || !end) return false;
+  const d = day.getTime();
+  return start.getTime() < d && d < end.getTime();
+}
+
+export function getDateLabel(selected) {
+  if (!selected) return '';
+  if (selected.type === 'custom') {
+    if (selected.range && selected.range.start && selected.range.end) {
+      const s = selected.range.start;
+      const e = selected.range.end;
+      return `${s.getFullYear()}.${s.getMonth()+1}.${s.getDate()}~${e.getFullYear()}.${e.getMonth()+1}.${e.getDate()}`;
+    }
+    if (selected.date) {
+      const d = selected.date;
+      return `${d.getFullYear()}.${d.getMonth()+1}.${d.getDate()}`;
+    }
+  }
+  if (selected === 'today') return '오늘';
+  if (selected === 'week') return '이번 주';
+  if (selected === 'month') return '이번 달';
+  return '';
+}
+
+export default function DateFilterModal({ open, onClose, onSelect, anchorRef, selected, dateType, onDateTypeChange }) {
+  const modalRef = useRef(null);
+  const [position, setPosition] = useState({ top: 0, left: 0, minWidth: 180 });
+  const today = new Date();
+  const [range, setRange] = useState({ start: null, end: null });
+  const [calendar, setCalendar] = useState({
+    year: today.getFullYear(),
+    month: today.getMonth(),
+  });
+  const dateTypeLabel = dateType === 'created' ? '생성일' : '최종 편집일';
+  const dateTypeOptions = [
+    { value: 'created', label: '생성일' },
+    { value: 'edited', label: '최종 편집일' },
+  ];
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+
+  useLayoutEffect(() => {
+    if (!open || !anchorRef?.current || !modalRef.current) return;
+    const rect = anchorRef.current.getBoundingClientRect();
+    setPosition({
+      top: rect.bottom + window.scrollY + 4,
+      left: rect.left + window.scrollX,
+      minWidth: rect.width || 180,
+    });
+  }, [open, anchorRef]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    function handleClick(e) {
+      if (
+        modalRef.current && !modalRef.current.contains(e.target) &&
+        anchorRef?.current && !anchorRef.current.contains(e.target)
+      ) {
+        onClose();
+      }
+    }
+    document.addEventListener('click', handleClick, true);
+    return () => document.removeEventListener('click', handleClick, true);
+  }, [open, onClose, anchorRef]);
+
+  function handleDatePick(day) {
+    const picked = new Date(calendar.year, calendar.month, day);
+    if (!range.start || (range.start && range.end)) {
+      setRange({ start: picked, end: null });
+    } else if (range.start && !range.end) {
+      if (picked.getTime() < range.start.getTime()) {
+        setRange({ start: picked, end: range.start });
+        onSelect({ type: 'custom', range: { start: picked, end: range.start } });
+      } else if (picked.getTime() === range.start.getTime()) {
+        setRange({ start: picked, end: picked });
+        onSelect({ type: 'custom', date: picked });
+        onClose();
+      } else {
+        setRange({ start: range.start, end: picked });
+        onSelect({ type: 'custom', range: { start: range.start, end: picked } });
+      }
+    }
+  }
+
+  function handlePresetClick(opt) {
+    let newRange = { start: null, end: null };
+    let newCalendar = { ...calendar };
+    if (opt.value === 'today') {
+      const t = new Date();
+      newRange = { start: t, end: t };
+      newCalendar = { year: t.getFullYear(), month: t.getMonth() };
+    } else if (opt.value === 'week') {
+      const t = new Date();
+      const day = t.getDay();
+      const start = new Date(t);
+      start.setDate(t.getDate() - day);
+      const end = new Date(t);
+      end.setDate(t.getDate() + (6 - day));
+      newRange = { start, end };
+      newCalendar = { year: start.getFullYear(), month: start.getMonth() };
+    } else if (opt.value === 'month') {
+      const t = new Date();
+      const start = new Date(t.getFullYear(), t.getMonth(), 1);
+      const end = new Date(t.getFullYear(), t.getMonth() + 1, 0);
+      newRange = { start, end };
+      newCalendar = { year: start.getFullYear(), month: start.getMonth() };
+    }
+    setRange(newRange);
+    setCalendar(newCalendar);
+    onSelect(opt.value);
+    onClose();
+  }
+
+  function handleReset() {
+    setRange({ start: null, end: null });
+    onSelect(null);
+  }
+
+  const days = getDaysInMonth(calendar.year, calendar.month);
+  const firstDay = new Date(calendar.year, calendar.month, 1).getDay();
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      ref={modalRef}
+      style={{
+        position: 'absolute',
+        top: position.top,
+        left: position.left,
+        minWidth: position.minWidth,
+        zIndex: 1000,
+        boxShadow: '0 4px 24px rgba(0,0,0,0.08)',
+      }}
+      className="p-2 bg-white border border-gray-200 rounded-lg"
+      onClick={e => e.stopPropagation()}
+      onMouseDown={e => e.stopPropagation()}
+    >
+      <div className="flex items-center justify-between mb-2">
+        <div className="relative">
+          <button
+            className="flex items-center px-2 py-1 text-xs bg-white hover:bg-gray-50"
+            onClick={() => setDropdownOpen(v => !v)}
+            type="button"
+          >
+            {dateTypeLabel}
+            <svg className="w-3 h-3 ml-1" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" /></svg>
+          </button>
+          {dropdownOpen && (
+            <ul className="absolute left-0 z-10 w-24 mt-1 bg-white border rounded shadow">
+              {dateTypeOptions.map(opt => (
+                <li
+                  key={opt.value}
+                  className={`w-24 px-3 py-1 text-xs cursor-pointer hover:bg-gray-200 ${dateType === opt.value ? 'bg-gray-100' : ''}`}
+                  onClick={() => { onDateTypeChange(opt.value); setDropdownOpen(false); }}
+                >
+                  {opt.label}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <button
+          className="px-2 py-1 text-xs rounded hover:bg-gray-200"
+          onClick={handleReset}
+        >
+          초기화
+        </button>
+      </div>
+      <ul className="overflow-y-auto divide-y divide-gray-100 min-w-[160px]">
+        {PRESETS.map(opt => (
+          <li
+            key={opt.value}
+            className={`py-1 px-2 cursor-pointer rounded ${selected && selected.type === 'custom' ? '' : opt.value === selected ? 'bg-gray-100' : 'hover:bg-gray-200'}`}
+            onClick={() => handlePresetClick(opt)}
+          >
+            {opt.label}
+          </li>
+        ))}
+      </ul>
+      <div className="p-2 mt-2 border rounded bg-gray-50">
+        <div className="flex items-center justify-between mb-2">
+          <button onClick={() => setCalendar(c => ({ ...c, month: c.month === 0 ? 11 : c.month - 1, year: c.month === 0 ? c.year - 1 : c.year }))}>&lt;</button>
+          <span>{calendar.year}년 {calendar.month + 1}월</span>
+          <button onClick={() => setCalendar(c => ({ ...c, month: c.month === 11 ? 0 : c.month + 1, year: c.month === 11 ? c.year + 1 : c.year }))}>&gt;</button>
+        </div>
+        <div className="grid grid-cols-7 gap-0 mb-1 text-xs text-center text-gray-500">
+          <div>일</div><div>월</div><div>화</div><div>수</div><div>목</div><div>금</div><div>토</div>
+        </div>
+        <div className="grid grid-cols-7 gap-0">
+          {Array(firstDay).fill(0).map((_, i) => <div key={i}></div>)}
+          {Array(days).fill(0).map((_, i) => {
+            const d = new Date(calendar.year, calendar.month, i+1);
+            const isToday = isSameDay(d, today);
+            const isStart = range.start && isSameDay(d, range.start);
+            const isEnd = range.end && isSameDay(d, range.end);
+            const inRange = range.start && range.end && isInRange(d, range.start, range.end);
+            if (inRange && isToday) {
+              return (
+                <button
+                  key={i+1}
+                  className="relative p-0 w-7 h-7"
+                  onClick={() => handleDatePick(i+1)}
+                >
+                  <div className="absolute inset-0 bg-blue-100"></div>
+                  <span className="relative z-10 flex items-center justify-center text-white bg-red-500 rounded-full w-7 h-7">{i+1}</span>
+                </button>
+              );
+            }
+            let btnClass = 'w-7 h-7 ';
+            if (isStart && isEnd) btnClass += 'bg-blue-500 text-white rounded-md';
+            else if (isStart) btnClass += 'bg-blue-500 text-white rounded-l-md';
+            else if (isEnd) btnClass += 'bg-blue-400 text-blue-700 rounded-r-md';
+            else if (isToday) btnClass += 'bg-red-500 text-white rounded-full';
+            else if (inRange) btnClass += 'bg-blue-100 text-blue-700';
+            else btnClass += 'hover:bg-blue-100 rounded-md';
+            return (
+              <button
+                key={i+1}
+                className={btnClass}
+                onClick={() => handleDatePick(i+1)}
+              >
+                {i+1}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+} 

--- a/frontend/src/components/layout/SearchFilters.jsx
+++ b/frontend/src/components/layout/SearchFilters.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Book, User, Calendar, ChevronDown } from 'lucide-react';
+
+export default function SearchFilters({ titleOnly, onToggleTitleOnly, onOpenAuthorModal, selectedAuthorName, authorButtonRef, onOpenDateModal, selectedDateLabel, dateButtonRef }) {
+  return (
+    <div className="flex gap-2 pl-3 mb-2">
+      <button
+        className={`pl-1 pr-3 py-1 rounded flex items-center gap-1 ${titleOnly ? 'bg-blue-50 text-blue-700 ' : 'text-gray-500'}`}
+        onClick={onToggleTitleOnly}
+      >
+        <Book className="w-4 h-4" />
+        제목만
+      </button>
+      <button
+        ref={authorButtonRef}
+        className={`flex items-center gap-1 px-3 py-1 rounded ${selectedAuthorName ? 'bg-blue-50 text-blue-700' : 'text-gray-500'}`}
+        onClick={onOpenAuthorModal}
+        type="button"
+      >
+        <User className="w-4 h-4" />
+        작성자
+        {selectedAuthorName && (
+          <span className="text-blue-700">: {selectedAuthorName}</span>
+        )}
+        <ChevronDown className="w-4 h-4" />
+      </button>
+      <button
+        ref={dateButtonRef}
+        className={`flex items-center gap-1 px-3 py-1 rounded ${selectedDateLabel ? 'bg-blue-50 text-blue-700' : 'text-gray-500'}`}
+        onClick={onOpenDateModal}
+        type="button"
+      >
+        <Calendar className="w-4 h-4" />
+        날짜
+        {selectedDateLabel && (
+          <span className="text-blue-700 ">: {selectedDateLabel}</span>
+        )}
+        <ChevronDown className="w-4 h-4" />
+      </button>
+    </div>
+  );
+} 

--- a/frontend/src/components/layout/SearchModal.jsx
+++ b/frontend/src/components/layout/SearchModal.jsx
@@ -2,6 +2,9 @@ import React, { useEffect, useRef, useState, useMemo } from 'react';
 import { useDocument } from '@/contexts/DocumentContext';
 import { useWorkspace } from '@/contexts/WorkspaceContext';
 import { useNavigate } from 'react-router-dom';
+import SearchFilters from './SearchFilters';
+import AuthorFilterModal from './AuthorFilterModal';
+import DateFilterModal, { getDateLabel } from './DateFilterModal';
 
 export default function SearchModal({ open, onClose }) {
   const inputRef = useRef(null);
@@ -10,6 +13,14 @@ export default function SearchModal({ open, onClose }) {
   const [query, setQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const navigate = useNavigate();
+  const [titleOnly, setTitleOnly] = useState(false);
+  const [selectedAuthor, setSelectedAuthor] = useState('');
+  const [authorModalOpen, setAuthorModalOpen] = useState(false);
+  const authorButtonRef = useRef(null);
+  const [dateModalOpen, setDateModalOpen] = useState(false);
+  const [selectedDateValue, setSelectedDateValue] = useState('');
+  const dateButtonRef = useRef(null);
+  const [selectedDateType, setSelectedDateType] = useState('created');
 
   // ESC 키로 닫기
   useEffect(() => {
@@ -50,22 +61,83 @@ export default function SearchModal({ open, onClose }) {
     return () => clearTimeout(handler);
   }, [query]);
 
-  // 최근 수정일 기준 정렬 및 30개 제한
-  const recentDocuments = useMemo(() => {
-    return [...documents]
-      .sort((a, b) => new Date(b.updatedAt || b.createdAt) - new Date(a.updatedAt || a.createdAt))
-      .slice(0, 30);
+  // 권한 있는 모든 작성자(userId, name) 추출
+  const authors = useMemo(() => {
+    const map = new Map();
+    documents.forEach(doc => {
+      if (doc.user && doc.user.userId && doc.user.name) {
+        map.set(doc.user.userId, doc.user.name);
+      }
+      // 권한자 목록도 포함(permissions)
+      if (Array.isArray(doc.permissions)) {
+        doc.permissions.forEach(p => {
+          if (p.userId && p.name) {
+            map.set(p.userId, p.name);
+          }
+        });
+      }
+    });
+    return Array.from(map, ([userId, name]) => ({ userId, name }));
   }, [documents]);
 
   // 검색 결과 필터링
   const results = useMemo(() => {
-    if (!debouncedQuery.trim()) return recentDocuments;
+    let filtered = documents;
+    if (selectedAuthor) {
+      filtered = filtered.filter(doc =>
+        (doc.user && doc.user.userId === selectedAuthor) ||
+        (Array.isArray(doc.permissions) && doc.permissions.some(p => p.userId === selectedAuthor))
+      );
+    }
+    // 날짜 필터 적용
+    if (selectedDateValue) {
+      filtered = filtered.filter(doc => {
+        const dateField = selectedDateType === 'created' ? doc.createdAt : doc.updatedAt;
+        if (!dateField) return false;
+        const date = new Date(dateField);
+        if (selectedDateValue === 'today') {
+          const now = new Date();
+          return date.getFullYear() === now.getFullYear() && date.getMonth() === now.getMonth() && date.getDate() === now.getDate();
+        }
+        if (selectedDateValue === 'week') {
+          const now = new Date();
+          const day = now.getDay();
+          const start = new Date(now);
+          start.setDate(now.getDate() - day);
+          const end = new Date(now);
+          end.setDate(now.getDate() + (6 - day));
+          return date >= start && date <= end;
+        }
+        if (selectedDateValue === 'month') {
+          const now = new Date();
+          return date.getFullYear() === now.getFullYear() && date.getMonth() === now.getMonth();
+        }
+        if (selectedDateValue?.type === 'custom') {
+          if (selectedDateValue.range && selectedDateValue.range.start && selectedDateValue.range.end) {
+            const s = selectedDateValue.range.start;
+            const e = selectedDateValue.range.end;
+            return date >= s && date <= e;
+          }
+          if (selectedDateValue.date) {
+            const d = selectedDateValue.date;
+            return date.getFullYear() === d.getFullYear() && date.getMonth() === d.getMonth() && date.getDate() === d.getDate();
+          }
+        }
+        return true;
+      });
+    }
+    if (!debouncedQuery.trim()) return filtered.sort((a, b) => new Date(b.updatedAt || b.createdAt) - new Date(a.updatedAt || a.createdAt)).slice(0, 30);
     const lower = debouncedQuery.toLowerCase();
-    return documents.filter(doc =>
+    if (titleOnly) {
+      return filtered.filter(doc =>
+        doc.title && doc.title.toLowerCase().includes(lower)
+      );
+    }
+    return filtered.filter(doc =>
       (doc.title && doc.title.toLowerCase().includes(lower)) ||
       (doc.content && doc.content.toLowerCase().includes(lower))
     );
-  }, [debouncedQuery, documents, recentDocuments]);
+  }, [debouncedQuery, documents, titleOnly, selectedAuthor, selectedDateValue, selectedDateType]);
 
   // HTML 태그 제거 함수
   function stripHtmlTags(html) {
@@ -96,9 +168,9 @@ export default function SearchModal({ open, onClose }) {
       <div
         ref={modalRef}
         className="bg-white rounded-lg shadow-lg"
-        style={{ width: '40vw', height: '50vh', minWidth: 320, minHeight: 320, display: 'flex', flexDirection: 'column' }}
+        style={{ width: '40vw', height: '50vh', minWidth: 800, minHeight: 500, display: 'flex', flexDirection: 'column' }}
       >
-        <div className="flex items-center w-full pl-3 mb-2">
+        <div className="flex items-center w-full pl-3 my-2">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-5 h-5 text-gray-400">
             <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 1010.5 18a7.5 7.5 0 006.15-3.35z" />
           </svg>
@@ -106,19 +178,47 @@ export default function SearchModal({ open, onClose }) {
             ref={inputRef}
             type="text"
             placeholder="문서 제목 또는 내용을 검색하세요..."
-            className="w-full px-3 py-3 rounded focus:outline-none"
+            className="w-full py-3 pl-2 pr-4 rounded focus:outline-none"
             value={query}
             onChange={e => setQuery(e.target.value)}
           />
         </div>
+        {/* 제목만 필터 버튼 분리 */}
+        <SearchFilters
+          titleOnly={titleOnly}
+          onToggleTitleOnly={() => setTitleOnly(v => !v)}
+          onOpenAuthorModal={() => setAuthorModalOpen(true)}
+          selectedAuthorName={selectedAuthor ? (authors.find(a => a.userId === selectedAuthor)?.name || '') : ''}
+          authorButtonRef={authorButtonRef}
+          onOpenDateModal={() => setDateModalOpen(true)}
+          selectedDateLabel={getDateLabel(selectedDateValue)}
+          dateButtonRef={dateButtonRef}
+        />
+        <AuthorFilterModal
+          open={authorModalOpen}
+          onClose={() => setAuthorModalOpen(false)}
+          authors={authors}
+          onSelectAuthor={setSelectedAuthor}
+          selectedAuthor={selectedAuthor}
+          anchorRef={authorButtonRef}
+        />
+        <DateFilterModal
+          open={dateModalOpen}
+          onClose={() => setDateModalOpen(false)}
+          onSelect={val => setSelectedDateValue(val)}
+          anchorRef={dateButtonRef}
+          selected={selectedDateValue}
+          dateType={selectedDateType}
+          onDateTypeChange={setSelectedDateType}
+        />
         <div className="flex-1 px-2 mt-4 overflow-y-auto">
-          <div className="px-2 mb-2 text-xs text-gray-400">
+          <div className="px-2 mb-2 text-xs text-gray-500">
             {debouncedQuery.trim() ? '검색 결과' : '최근 문서'}
           </div>
           {documentsLoading ? (
-            <div className="mt-8 text-center text-gray-400">문서 목록 불러오는 중...</div>
+            <div className="mt-8 text-center text-gray-500">문서 목록 불러오는 중...</div>
           ) : debouncedQuery.trim() && results.length === 0 ? (
-            <div className="mt-8 text-center text-gray-400">검색 결과가 없습니다.</div>
+            <div className="mt-8 text-center text-gray-500">검색 결과가 없습니다.</div>
           ) : (
             <ul className="divide-y divide-gray-100">
               {results.map(doc => (
@@ -131,7 +231,7 @@ export default function SearchModal({ open, onClose }) {
                     {highlightText(doc.title || '제목 없음', debouncedQuery)}
                   </div>
                   <div className="text-sm text-gray-500 truncate">
-                    {highlightText(stripHtmlTags(doc.content)?.slice(0, 60), debouncedQuery)}
+                    {highlightText(stripHtmlTags(doc.content)?.slice(0, 80), debouncedQuery)}
                   </div>
                 </li>
               ))}

--- a/frontend/src/components/notifications/Notifications.jsx
+++ b/frontend/src/components/notifications/Notifications.jsx
@@ -8,7 +8,7 @@ export default function Notifications() {
   return (
     <>
       <button
-        className="flex items-center w-full p-4 border-t border-gray-200 hover:bg-gray-50"
+        className="flex items-center w-full px-4 py-2 border-gray-200 hover:bg-gray-50"
         onClick={() => setOpen(true)}
       >
         <Bell className="w-5 h-5 mr-2" />


### PR DESCRIPTION
- 날짜 필터 드롭다운(생성일/최종 편집일) 및 초기화 버튼 추가
- 날짜, 작성자, 제목만 필터 버튼에 아이콘 및 드롭다운 꺽쇠 추가
- 날짜 필터 적용 시 문서 목록 실제 필터링
- 날짜 필터 초기화 시 전체 해제 및 라벨/프리셋 반영
- DateFilterModal Portal 적용 및 외부 클릭 UX 개선

close #4